### PR TITLE
improvement

### DIFF
--- a/src/main/scala/edu/nd/dsg/bshi/ArgLoader.scala
+++ b/src/main/scala/edu/nd/dsg/bshi/ArgLoader.scala
@@ -30,6 +30,8 @@ trait ArgLoader {
                     filePath: String = "", // Path of file, should be on hdfs
                     titlePath: String = "",// Path of title-id map, should be on local disk
                     outPath: String = "", // Output path, should be a local location
+                    sample: Int = 5, // Number of sample nodes
+                    directed: Boolean = true, // Whether this is a directed graph or not
                    // Misc
                     nCores: Int = 4, // Number of cores for Spark
                     file: String = "" // log4j properties
@@ -65,6 +67,14 @@ trait ArgLoader {
     opt[Int]("lpaEnd") action {
       (x,c) => c.copy(lpaEnd = x)
     } text "Max iteration of LPA community detection"
+
+    opt[Int]('s', "sample") action {
+      (x,c) => c.copy(sample = x)
+    } text "Number of random starting nodes, default is 5"
+
+    opt[Boolean]('d', "directed") action {
+      (x,c) => c.copy(directed = x)
+    } text "directed graph or not, default is directed graph"
 
     opt[VertexId]('q', "query") action {
       (x,c) => c.copy(queryId = x)

--- a/src/main/scala/edu/nd/dsg/bshi/CommunityDetection.scala
+++ b/src/main/scala/edu/nd/dsg/bshi/CommunityDetection.scala
@@ -28,7 +28,7 @@ object CommunityDetection extends ExperimentTemplate with ArgLoader with OutputW
 
     vertices = sc.parallelize(file.map(_.toSet).reduce(_ ++ _).toSeq.map(x => (x.toLong, 0.0)))
 
-    edges = file.map(x => Edge(x(0), x(1), true))
+    edges = file.map(x => Edge(x(0), x(1), true)) ++ file.map(x => Edge(x(1), x(0), true))
 
     graph = Graph(vertices, edges)
 
@@ -51,7 +51,7 @@ object CommunityDetection extends ExperimentTemplate with ArgLoader with OutputW
       })
     })
 
-    writeResult(config.outPath, finalResult, Range(config.lpaStart, config.lpaEnd, config.lpastep).map(_.toString+"iter"))
+    writeResult(config.outPath, finalResult)
 
   }
 }

--- a/src/main/scala/edu/nd/dsg/bshi/ForwardBackwardPPRRanking.scala
+++ b/src/main/scala/edu/nd/dsg/bshi/ForwardBackwardPPRRanking.scala
@@ -1,8 +1,5 @@
 package edu.nd.dsg.bshi
 
-import java.io.{File, PrintWriter}
-
-import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.graphx._
 import org.apache.spark.rdd.RDD
 
@@ -16,9 +13,6 @@ import scala.collection.mutable
  * s and s' will be the initial score of source or the total score of entire graph in FPPR and BPPR
  */
 object ForwardBackwardPPRRanking extends ExperimentTemplate with OutputWriter[String] {
-
-  // Keys that we will write
-  val stringKeys = Seq("title", "fppr_score", "fppr_rank", "bppr_score", "bppr_rank","Num_of_rel")
 
   /**
    * Load graph and save to graph variable
@@ -43,15 +37,19 @@ object ForwardBackwardPPRRanking extends ExperimentTemplate with OutputWriter[St
 
     vertices = sc.parallelize(file.map(_.toSet).reduce(_ ++ _).toSeq.map(x => (x.toLong, 0.0)))
 
-    edges = file.map(x => Edge(x(0), x(1), true))
+    edges = if (config.directed) {
+      file.map(x => Edge(x(0), x(1), true))
+    } else { // Convert to undirected if not directed
+      file.map(x => Edge(x(1), x(0), true)) ++ file.map(x => Edge(x(1), x(0), true))
+    }
 
-    graph = Graph(vertices, edges)
+    graph = Graph(vertices.distinct(), edges.distinct()) // Make sure there is no duplication
 
     Seq("","Graph statistics:",
       "--Vertices: " + graph.numVertices,
       "--Edges:    " + graph.numEdges).foreach(println)
 
-    if (graph.vertices.filter(_._1 == config.queryId).count() == 0) {
+    if (config.queryId != 0l && graph.vertices.filter(_._1 == config.queryId).count() == 0) {
       println("QueryId ", config.queryId, " does not exist!")
       sc.stop()
       return
@@ -68,38 +66,47 @@ object ForwardBackwardPPRRanking extends ExperimentTemplate with OutputWriter[St
   def run(): Unit = {
     println(math.pow(1-config.alpha,config.c.toDouble))
 
-    var Initial_node = Array[Long](config.queryId)
-    val newgraph = Graph(setInitialP(Initial_node), edges)
-    val resGraph = PersonalizedPageRank.runWithInitialScore(newgraph, config.queryId, config.maxIter, config.alpha)
-    val fpprRankTopK = DataExtractor.extractTopKFromPageRank(resGraph,titleMap, config.topK)
+    val sampledNodes = if(config.queryId == 0l) {
+      val tmp = graph.vertices.innerJoin(graph.outDegrees)((vid, data, outdeg) => outdeg)
+        .filter(_._2 >= 10)
 
-    fpprRankTopK.foreach(elem =>{
-      if (!finalResult.contains(elem._1)) {
-        finalResult(elem._1) = new mutable.HashMap[String, String]()
-        finalResult(elem._1)("title")=elem._2.toString
-        finalResult(elem._1)("fppr_score")=elem._4.toString
-        finalResult(elem._1)("fppr_rank")=elem._3.toString
-      }
-      else {
-        finalResult(elem._1)("title") = elem._2.toString
-        finalResult(elem._1)("fppr_score") = elem._4.toString
-        finalResult(elem._1)("fppr_rank") = elem._3.toString
-      }
+      println(tmp.count(), config.sample.toDouble,config.sample.toDouble / tmp.count())
+
+      tmp.sample(false, if(config.sample.toDouble > tmp.count()) 1 else config.sample.toDouble / tmp.count(), 2l).map(_._1).collect().toSeq
+    } else Seq(config.queryId)
+
+    println("sample nodes are " + sampledNodes)
+
+    sampledNodes.foreach(queryId => {
+      var Initial_node = Array[Long](queryId)
+      val newgraph = Graph(setInitialP(Initial_node), edges)
+      val resGraph = PersonalizedPageRank.runWithInitialScore(newgraph, queryId, config.maxIter, config.alpha)
+      val fpprRankTopK = DataExtractor.extractTopKFromPageRank(resGraph,titleMap, config.topK)
+
+      fpprRankTopK.foreach(elem =>{
+        if (!finalResult.contains(elem._1)) {
+          finalResult(elem._1) = new mutable.HashMap[String, String]()
+        }
+          finalResult(elem._1)("title") = elem._2.toString
+          finalResult(elem._1)("query_id") = queryId.toString
+          finalResult(elem._1)("fppr_score")=elem._4.toString
+          finalResult(elem._1)("fppr_rank")=elem._3.toString
+      })
+
+      fpprRankTopK.foreach(elem => {
+        Initial_node = Array[Long](elem._1)
+        val invgraph = Graph(setInitialP(Initial_node), graph.edges.reverse)
+        val resGraph = PersonalizedPageRank.runWithInitialScore(invgraph, elem._1, config.maxIter, config.alpha)
+        val ans = DataExtractor.extractNodeFromPageRank(resGraph, titleMap, queryId)
+        finalResult(elem._1)("bppr_score") = ans.head._4.toString
+        finalResult(elem._1)("bppr_rank") = ans.head._3.toString
+        println(finalResult(elem._1))
+        invgraph.unpersist(blocking = false)
+        resGraph.unpersist(blocking = false)
+      })
     })
 
-    fpprRankTopK.foreach(elem => {
-      Initial_node = Array[Long](elem._1)
-      val invgraph = Graph(setInitialP(Initial_node), graph.edges.reverse)
-      val resGraph = PersonalizedPageRank.runWithInitialScore(invgraph, elem._1, config.maxIter, config.alpha)
-      val ans = DataExtractor.extractNodeFromPageRank(resGraph, titleMap, config.queryId)
-      finalResult(elem._1)("bppr_score") = ans.head._4.toString
-      finalResult(elem._1)("bppr_rank") = ans.head._3.toString
-      finalResult(elem._1)("Num_of_rel") = resGraph.vertices.filter(
-        x=> x._2 > math.pow(1-config.alpha, config.c.toDouble)).count().toString
-      println(finalResult(elem._1)("Num_of_rel"))
-    })
-
-    writeResult(config.outPath, finalResult, stringKeys)
+    writeResult(config.outPath, finalResult)
     println("Finished!")
   }
 

--- a/src/main/scala/edu/nd/dsg/bshi/ForwardPPRBackwardPR.scala
+++ b/src/main/scala/edu/nd/dsg/bshi/ForwardPPRBackwardPR.scala
@@ -116,7 +116,7 @@ object ForwardPPRBackwardPR extends ExperimentTemplate with OutputWriter[String]
       println("bpr"+iterNum.toString+" stored")
     }
 
-    writeResult(config.outPath, finalResult, stringKeys)
+    writeResult(config.outPath, finalResult)
 
   }
 

--- a/src/main/scala/edu/nd/dsg/bshi/Main.scala
+++ b/src/main/scala/edu/nd/dsg/bshi/Main.scala
@@ -4,7 +4,7 @@ object Main {
 
   def main(args: Array[String]): Unit = {
 
-    CommunityDetection.load(args)
-    CommunityDetection.run()
+    ForwardBackwardPPRRanking.load(args)
+    ForwardBackwardPPRRanking.run()
   }
 }

--- a/src/main/scala/edu/nd/dsg/bshi/OutputWriter.scala
+++ b/src/main/scala/edu/nd/dsg/bshi/OutputWriter.scala
@@ -16,11 +16,10 @@ trait OutputWriter[T] {
    * Write result to a file
    * @param filePath output file path
    * @param resMap a nested output HashMap {id:{key:val, ...}, ...}
-   * @param stringKeys a list of keys in HashMap
    */
   def writeResult(filePath: String,
                   resMap: mutable.HashMap[VertexId, mutable.HashMap[String, T]],
-                  stringKeys: Seq[String]): Unit = {
+                  stringKeys: Seq[String] = Seq[String]()): Unit = {
     val writer = new PrintWriter(new File(filePath))
 
     writer.write(resToString(resMap, stringKeys))
@@ -29,19 +28,21 @@ trait OutputWriter[T] {
 
   }
 
-  def resToString(resMap: mutable.HashMap[VertexId, mutable.HashMap[String, T]],
-               stringKeys: Seq[String]): String = {
+  def resToString(resMap: mutable.HashMap[VertexId, mutable.HashMap[String, T]], stringKeys: Seq[String] = Seq[String]()): String = {
     val str = new mutable.StringBuilder
-    str.append((Seq("id") ++ stringKeys).reduce(_+","+_)+"\n")
+    val keys = if(resMap.size > 0) {
+      resMap.map(_._2.keySet).reduce(_ ++ _) ++ stringKeys.toSet
+    }.toSeq  else stringKeys
+    str.append((Seq("id") ++ keys).reduce(_+","+_)+"\n")
     resMap.map(elem => {
-      val tuple = Seq(elem._1.toString) ++ stringKeys.map(x => elem._2.getOrElse(x, "NA").toString).map(_.replace(","," "))
+      val tuple = Seq(elem._1.toString) ++ keys.map(x => elem._2.getOrElse(x, "NA").toString).map(_.replace(","," "))
       str.append(tuple.reduce(_+","+_)+"\n")
     })
     str.toString()
   }
 
   def printResult(resMap: mutable.HashMap[VertexId, mutable.HashMap[String, T]],
-                  stringKeys: Seq[String]): Unit = {
+                  stringKeys: Seq[String] = Seq[String]()): Unit = {
     print(resToString(resMap, stringKeys))
   }
 

--- a/src/main/scala/edu/nd/dsg/bshi/PairwisePPR.scala
+++ b/src/main/scala/edu/nd/dsg/bshi/PairwisePPR.scala
@@ -75,7 +75,7 @@ object PairwisePPR extends ExperimentTemplate with OutputWriter[String] {
       candidateSet.map(_.toString+"_score").toSeq
 
 //    printResult(finalResult, finalKeys)
-    writeResult(config.outPath, finalResult, finalKeys)
+    writeResult(config.outPath, finalResult)
 
   }
 


### PR DESCRIPTION
add node sampling
add threshold to avoid doing PPR on disconnected nodes
now OutputWriter can automatically detect output keys
Now this can take any edgelist files including directed and undirected graph
_rank based classifier is temporarily removed from master branch_
